### PR TITLE
export library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ find_package(catkin REQUIRED)
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
 #  INCLUDE_DIRS include
-#  LIBRARIES DrRobotMotionSensorDriver
+ LIBRARIES DrRobotMotionSensorDriver
 #  CATKIN_DEPENDS other_catkin_pkg
 #  DEPENDS system_lib
 )


### PR DESCRIPTION
Export DrRobotMotionSensorDriver library for automatic discovery by other catkin packages (like drrobot_jaguar4x4_player)
